### PR TITLE
Add dispatch method for main queue support

### DIFF
--- a/iCloudStorage.m
+++ b/iCloudStorage.m
@@ -122,6 +122,11 @@ static NSString* const kChangedKeys = @"changedKeys";
     return YES;
 }
 
+- (dispatch_queue_t)methodQueue
+{
+    return dispatch_get_main_queue();
+}
+
 - (NSArray<NSString *> *)supportedEvents {
   return @[ kStoreChangedEvent ];
 }


### PR DESCRIPTION
I THINK this will fix the warning about main queue setup that's coming with the newer versions of react-native.

Well at least it goes away with this change and I saw that some other projects fixed it this way, but I'm not 100% certain.

https://github.com/manicakes/react-native-icloudstore/issues/7

