### PR TITLE
fix multiSet signature to match that of AsyncStorage

### DIFF
--- a/iCloudStorage.m
+++ b/iCloudStorage.m
@@ -224,10 +224,10 @@ RCT_EXPORT_METHOD(multiGet: (NSArray*)keys resolver:(RCTPromiseResolveBlock)reso
   resolve(result);
 }
 
-RCT_EXPORT_METHOD(multiSet: (NSDictionary*)keyValuePairs resolver:(RCTPromiseResolveBlock)resolve
+RCT_EXPORT_METHOD(multiSet: (NSArray<NSArray<NSString *> *> *)keyValuePairs resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-  for (NSString* key in [keyValuePairs allKeys]) {
-    [iCloudStorage setValue:[keyValuePairs objectForKey:key] forKey:key];
+  for (NSArray<NSString *> *entry in keyValuePairs) {
+    [iCloudStorage setValue:entry[1] forKey:entry[0]];
   }
   resolve(@{});
 }


### PR DESCRIPTION
this pr changes the signature of iCloudStorage.multiSet to match that of AsyncStorage: https://reactnative.dev/docs/asyncstorage#multiset