### PR TITLE
Match multiGet and multiSet signatures with that of AsyncStorage

### DIFF
--- a/iCloudStorage.m
+++ b/iCloudStorage.m
@@ -216,9 +216,10 @@ RCT_EXPORT_METHOD(multiGet: (NSArray*)keys resolver:(RCTPromiseResolveBlock)reso
   NSMutableArray *result = [NSMutableArray arrayWithCapacity:[keys count]];
   for (NSString* key in keys) {
     NSObject* object = [iCloudStorage getObjectForKey:key];
-    if (object != nil) {
-      [result addObject:object];
+    if (object == nil) {
+      object = [NSNull null];
     }
+    [result addObject:@[key, object]];
   }
   
   resolve(result);

--- a/iCloudStorage.m
+++ b/iCloudStorage.m
@@ -224,10 +224,10 @@ RCT_EXPORT_METHOD(multiGet: (NSArray*)keys resolver:(RCTPromiseResolveBlock)reso
   resolve(result);
 }
 
-RCT_EXPORT_METHOD(multiSet: (NSDictionary*)keyValuePairs resolver:(RCTPromiseResolveBlock)resolve
+RCT_EXPORT_METHOD(multiSet: (NSArray<NSArray<NSString *> *> *)keyValuePairs resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-  for (NSString* key in [keyValuePairs allKeys]) {
-    [iCloudStorage setValue:[keyValuePairs objectForKey:key] forKey:key];
+  for (NSArray<NSString *> *entry in keyValuePairs) {
+    [iCloudStorage setValue:entry[1] forKey:entry[0]];
   }
   resolve(@{});
 }


### PR DESCRIPTION
`react-native-icloudstore`'s iOS implementations of `multiGet()` and `multiSet()` do not correctly adhere to the I/O protocols that AsyncStorage adheres to, creating a mismatch when writing code that falls back to AsyncStorage on Android.

This PR fixes both `multiGet()` (fixed its outbound return value) and `multiSet()` (fixed its inbound parameters).

/cc @puckey