### PR TITLE
Import AsyncStorage from @react-native-async-storage to silence warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,8 @@
  * @providesModule react-native-icloudstore
  */
 
-import { AsyncStorage, NativeModules, Platform } from 'react-native';
+import { NativeModules, Platform } from 'react-native';
+import AsyncStorage from "@react-native-async-storage/async-storage";
 
 const iCloudStorage = Platform.OS === 'ios' || Platform.isTVOS ? NativeModules.RNICloudStorage : AsyncStorage;
 

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
   "bugs": {
     "url": "https://github.com/manicakes/react-native-icloudstore/issues"
   },
-  "homepage": "https://github.com/manicakes/react-native-icloudstore#readme"
+  "homepage": "https://github.com/manicakes/react-native-icloudstore#readme",
+  "dependencies": {
+    "@react-native-async-storage/async-storage": "^1.17.0"
+  }
 }


### PR DESCRIPTION
This pull request aims to replace the deprecated import from react-native with the new package @react-native-async-storage.

I am not sure whether we need to add react-native to the dependencies as well or why it was not listed before. 